### PR TITLE
Render game using SVG assets

### DIFF
--- a/assets/background.svg
+++ b/assets/background.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#87CEEB"/>
+  <rect y="28" width="32" height="4" fill="#DEB887"/>
+</svg>

--- a/assets/bird.svg
+++ b/assets/bird.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="12" cy="16" r="10" fill="#FFD700" stroke="#FF8C00" stroke-width="2"/>
+  <polygon points="20,16 30,12 30,20" fill="#FFA500"/>
+  <circle cx="10" cy="14" r="3" fill="#FFFFFF"/>
+  <circle cx="10" cy="14" r="1.5" fill="#000000"/>
+</svg>

--- a/assets/obstacle.svg
+++ b/assets/obstacle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="12" y="0" width="8" height="32" fill="#228B22"/>
+  <rect x="8" y="0" width="16" height="6" fill="#32CD32"/>
+</svg>

--- a/assets/reward.svg
+++ b/assets/reward.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <polygon points="16,2 20,12 31,12 22,18 25,28 16,22 7,28 10,18 1,12 12,12" fill="#FFD700" stroke="#FFA500" stroke-width="1"/>
+</svg>


### PR DESCRIPTION
## Summary
- Load SVG assets for bird, obstacles, rewards, and background and build a tile renderer using them.
- Include SVG artwork for flappy-bird style background, bird, obstacle, and reward tiles.
- Add fallback import for OpenCV so game logic can run without GUI libraries.

## Testing
- `python -m py_compile blockrun.py`
- `python - <<'PY'
from blockrun import BlockRun, map_view_to_image
br = BlockRun(50, device='cpu')
view = br.render()
img = map_view_to_image(view)
print('image tensor shape', img.shape, 'dtype', img.dtype)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689c46194d908322b59b9c45de1ecfea